### PR TITLE
Fix issue #67 and unnecessary bytecode duplication (rebased)

### DIFF
--- a/subzero/dist.py
+++ b/subzero/dist.py
@@ -112,7 +112,6 @@ class build_exe(distutils.core.Command):
             options.setdefault(default_option, [])
 
         # by convention, all paths appended to py_options must be absolute
-        options['hiddenimports'].extend(self.distribution.install_requires)
         for lib_dir in lib_dirs:
             if os.path.isdir(os.path.join(self.build_base, lib_dir)):
                 options['pathex'].append(
@@ -120,10 +119,6 @@ class build_exe(distutils.core.Command):
 
         if not options['pathex']:
             raise ValueError('Unable to find lib directory!')
-
-        if version.parse(sys.version[0:3]) >= version.parse('3.4'):
-            for package in self.distribution.packages:
-                options['hiddenimports'].extend(collect_submodules(package))
 
         options['specpath'] = os.path.abspath(self.build_temp)
         options['pathex'].append(os.path.abspath(self.build_temp))
@@ -236,9 +231,15 @@ class build_exe(distutils.core.Command):
         return module_files, binary_files
 
     def _discover_dependencies(self, options):
+        # Requirements cannot be assumed to be modules / packages
+        #options['hiddenimports'].extend(self.distribution.install_requires)
+
+        if version.parse(sys.version[0:3]) >= version.parse('3.4'):
+            for package in self.distribution.packages:
+                options['hiddenimports'].extend(collect_submodules(package))
+
         module_files = self._compile_modules()
-        required_module_files, required_binary_files = self._compile_requirements(
-        )
+        required_module_files, required_binary_files = self._compile_requirements()
 
         for required_file in required_module_files:
             try:
@@ -269,8 +270,6 @@ class build_exe(distutils.core.Command):
             fh.write("import {0}\n".format(entry_point.module_name))
             fh.write("{0}.{1}()\n".format(entry_point.module_name, '.'.join(
                 entry_point.attrs)))
-            for package in self.distribution.packages:
-                fh.write("import {0}\n".format(package))
 
             fh.seek(0)
             assert '==' not in fh.read()

--- a/subzero/dist.py
+++ b/subzero/dist.py
@@ -94,7 +94,8 @@ class build_exe(distutils.core.Command):
 
         scripts = copy(self.distribution.scripts)
         self.distribution.scripts = []
-        for required_directory in [self.build_temp, self.build_exe]:
+        build_exe_temp = '{}.temp'.format(self.build_exe)
+        for required_directory in [self.build_temp, self.build_exe, build_exe_temp]:
             shutil.rmtree(required_directory, ignore_errors=True)
             os.makedirs(required_directory, exist_ok=True)
 
@@ -144,23 +145,20 @@ class build_exe(distutils.core.Command):
         for executable in executables:
             rename_script(executable)
 
-        names = [executable.options['name'] for executable in executables]
         for executable in executables:
-            self._freeze(executable, self.build_temp, self.build_exe)
+            self._freeze(executable, self.build_temp, build_exe_temp)
 
+        ## TODO: Compare file hashes to make sure we haven't replaced files with a different version
+        names = [executable.options['name'] for executable in executables]
         for name in names[1:]:
             move_tree(
-                os.path.join(self.build_exe, name),
-                os.path.join(self.build_exe, names[0]))
+                os.path.join(build_exe_temp, name),
+                os.path.join(build_exe_temp, names[0]))
 
-        move_tree(os.path.join(self.build_exe, names[0]), self.build_exe)
+        move_tree(os.path.join(build_exe_temp, names[0]), self.build_exe)
 
         shutil.rmtree(self.build_temp, ignore_errors=True)
-
-        # TODO: Compare file hashes to make sure we haven't replaced files with a different version
-        for name in names:
-            shutil.rmtree(
-                os.path.join(self.build_exe, name), ignore_errors=True)
+        shutil.rmtree(build_exe_temp, ignore_errors=True)
 
     @make_spin(Spin1, 'Compiling module file locations...')
     def _compile_modules(self):


### PR DESCRIPTION
This pull request does four things:

1. fixes issue #67 (data files being accidentally removed in final merge)
2. moves additions to `hiddenimports` to `_discover_dependencies` method (so that they are only added if user sets `'optimize_imports': False` option
3. disables addition of `install_requires` dependencies to `hiddenimports` (because `install_requires` specify names of PyPI packages, sometimes even specific versions, which aren't valid Python package/module names in many cases)
4. disables writing `import` statements for all packages specified in `setup` to generated executable scripts (because this adds unnecessary dependencies to generated executables if multiple executables are specified and according to my tests this isn't needed at all)

Thanks to these changes, if more executables are specified in `setup`, unnecessary dependencies from one executable aren't added to all other executables.